### PR TITLE
Fix GoReleaser CI #6

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -22,6 +22,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hello 👋 I am opening this PR to resolve #6 

I have updated the command-line args to reflect the latest changes in GoReleaser. 
The `--rm-dist` flag has been deprecated ([see details](https://goreleaser.com/deprecations/#-rm-dist)), and the recommended replacement is `--clean`, which properly removes the dist folder

The workflow has been tested successfully on my fork: [Workflow run](https://github.com/Antoineio/lorelai/actions/runs/13832866771/job/38700975079).

Let me know if any adjustments are needed. 🙏