### PR TITLE
Add more web domains #5

### DIFF
--- a/pkg/convenience.go
+++ b/pkg/convenience.go
@@ -7,7 +7,7 @@ import (
 
 // Get a random Domain
 func Domain() string {
-	return trimSpaceAddDot(LoremWords(1)) + [5]string{"com", "net", "org", "io", "pe"}[rand.Intn(5)]
+	return trimSpaceAddDot(LoremWords(1)) + TLDS[rand.Intn(len(TLDS))]
 }
 
 // Get a random URL

--- a/pkg/convenience_test.go
+++ b/pkg/convenience_test.go
@@ -7,9 +7,8 @@ import (
 
 func TestDomain(t *testing.T) {
 	domain := Domain()
-	extensions := []string{"com", "net", "org", "io", "pe"}
 	valid := false
-	for _, v := range extensions {
+	for _, v := range TLDS {
 		if strings.HasSuffix(domain, v) {
 			valid = true
 			break

--- a/pkg/tlds.go
+++ b/pkg/tlds.go
@@ -1,0 +1,45 @@
+package lorelai
+
+var TLDS = []string{
+	// Most popular ccTLDs (Country Code Top-Level Domains)
+	"com", // Commercial (generic but widely used)
+	"net", // Network (generic but widely used)
+	"org", // Organization (generic but widely used)
+	"fr",  // France
+	"de",  // Germany
+	"uk",  // United Kingdom
+	"cn",  // China
+	"ru",  // Russia
+	"br",  // Brazil
+	"in",  // India
+	"jp",  // Japan
+	"ca",  // Canada
+	"us",  // United States
+	"it",  // Italy
+	"au",  // Australia
+	"es",  // Spain
+	"nl",  // Netherlands
+	"se",  // Sweden
+	"mx",  // Mexico
+	"ch",  // Switzerland
+	"pl",  // Poland
+	"ar",  // Argentina
+	"be",  // Belgium
+	"no",  // Norway
+	"at",  // Austria
+	"dk",  // Denmark
+	"fi",  // Finland
+	"pe",  // Peru
+
+	// Most popular Short TLDs
+	"io",  // Tech / Startups
+	"co",  // Colombia (also used for businesses)
+	"ai",  // Artificial Intelligence / Anguilla
+	"tv",  // Television / Tuvalu
+	"me",  // Montenegro (commonly used for personalization)
+	"app", // Apps (generic)
+	"dev", // Developers (generic)
+	"xyz", // Generic, widely used
+	"biz", // Business
+	"pro", // Professionals
+}

--- a/pkg/tlds_test.go
+++ b/pkg/tlds_test.go
@@ -1,0 +1,13 @@
+package lorelai
+
+import (
+	"testing"
+)
+
+func TestTLDSLength(t *testing.T) {
+	for _, tld := range TLDS {
+		if len(tld) < 2 || len(tld) > 63 {
+			t.Errorf("Invalid TLD '%s' (length: %d). Must be between 2 and 63 characters", tld, len(tld))
+		}
+	}
+}


### PR DESCRIPTION
Hello 👋,

I am opening this PR to resolve #5 

I moved TLDs to **a separate file** (`tlds.go`) for better maintainability
This refactor allowed me to update the `Domain()` function to use the extracted `TLDS` list dynamically instead of hardcoded values

I also updated the `TestDomain()` function to also use the `TLDS` list

Finally, i added a new test, `TestTLDsLength()`, to validate TLD lengths
I added this test because, while researching the most commonly used TLDs, i came across [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4), which states that a label must be **a maximum of 63 characters**. While adhering to this standard is not mandatory, but i believe it's a good practice :man_shrugging:

Let me know if any adjustments are needed. 🙏